### PR TITLE
Solved the issue where the program does not recognise the OS when using Windows

### DIFF
--- a/Peregrine/peregrine.v
+++ b/Peregrine/peregrine.v
@@ -118,7 +118,7 @@ fn main() {
 	mut outfile := ''
 	mut idx_ := 0
 	mut ext:=''
-	if '${os.user_os}'=="windows"{
+	if '${os.user_os()}'=="windows"{
 		ext = ".exe"
 	}
 	for idx, x in arg {


### PR DESCRIPTION
Added  parentheses to os.user_os so that the call returns the OS instead of fn() String.