### PR TITLE
Remove redundant conditions

### DIFF
--- a/Peregrine/builtin.h
+++ b/Peregrine/builtin.h
@@ -297,11 +297,13 @@ double mypow(double base, double power) {
     }
 
     return result;
-  } else if (power < 0) {
+  } else {
     while (power++) {
       result = result * base;
     }
-    return 1 / result;
+    if(base!=0)
+      return 1 / result;
+    else return 0;
   }
 }
 int compare(char *a, char *b) {


### PR DESCRIPTION
There is no need to check if power<0 since it's on the else of (power>=0) which will always be true.
If the base is equal to 0, the return of 1/0 will throw an error, which could be solved by just returning 0 since 0^x is 0 for every x.
