### PR TITLE
Move `Token` class from `lexer.py` to `tokens.py`

### DIFF
--- a/Peregrine/lexer/lexer.py
+++ b/Peregrine/lexer/lexer.py
@@ -1,10 +1,6 @@
-from dataclasses import dataclass
-
 # peregrine has builtin support for structure so it is not needed when we write in peregrine
 from .tokens import *
 from errors import errors
-
-
 
 
 def equal(

--- a/Peregrine/lexer/tokens.py
+++ b/Peregrine/lexer/tokens.py
@@ -5,6 +5,7 @@
 """
 
 from enum import IntEnum, auto
+from dataclasses import dataclass
 
 @dataclass
 class Token:  # change class to struct


### PR DESCRIPTION
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
- Move `Token` class from `lexer.py` to `tokens.py`

Explain the **details** for making this change. What existing problem does the pull request solve?
- `parser.py` only imports `tokens.py` but depends on the `Token` class (which is currently located at `lexer.py`). Moving the `Token` class to `tokens.py` fixes this issue.
- `Token` class is more appropriate to be placed in `tokens.py` than `lexer.py`
- Everything still works. (tested by running `py peregrine.py`)

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
